### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For larger sections. This keeps your content centered if you use squid with a ma
 ```
 .row
 ```
-For rows of content. Use the modifier class `.row-vertical` for vertical rows.
+For rows of content. Use the modifier class `.row--vertical` for vertical rows.
 
 
 ### Width and height


### PR DESCRIPTION
I just saw that the README references a non-existing class `row-vertical`.
I'm pretty sure that it should be `row--vertical` instead?

Thanks for making squid-css!